### PR TITLE
HTTP endpoint to trigger Docker service sync

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -18,10 +18,11 @@ type Service struct {
 	Ip      net.IP
 	Ttl     int
 	Aliases []string
+	Manual  bool
 }
 
 func NewService() (s *Service) {
-	s = &Service{Ttl: -1}
+	s = &Service{Ttl: -1, Manual: false}
 	return
 }
 

--- a/docker.go
+++ b/docker.go
@@ -47,7 +47,10 @@ func (d *DockerManager) Start() error {
 			log.Println(err)
 			continue
 		}
-		d.list.AddService(container.Id, *service)
+		s, err := d.list.GetService(container.Id)
+		if err != nil || !s.Manual {
+			d.list.AddService(container.Id, *service)
+		}
 	}
 
 	return nil
@@ -89,10 +92,14 @@ func (d *DockerManager) getService(id string) (*Service, error) {
 func (d *DockerManager) eventCallback(event *dockerclient.Event, ec chan error, args ...interface{}) {
 	//log.Printf("Received event: %#v %#v\n", *event, args)
 
+	s, s_err := d.list.GetService(event.Id)
+
 	switch event.Status {
 	case "die", "stop", "kill":
 		// Errors can be ignored here because there can be no-op events.
-		d.list.RemoveService(event.Id)
+		if s_err == nil && !s.Manual {
+			d.list.RemoveService(event.Id)
+		}
 	case "start", "restart":
 		service, err := d.getService(event.Id)
 		if err != nil {
@@ -100,7 +107,9 @@ func (d *DockerManager) eventCallback(event *dockerclient.Event, ec chan error, 
 			return
 		}
 
-		d.list.AddService(event.Id, *service)
+		if s_err != nil || !s.Manual {
+			d.list.AddService(event.Id, *service)
+		}
 	}
 }
 

--- a/docker.go
+++ b/docker.go
@@ -36,7 +36,7 @@ func (d *DockerManager) Start() error {
 		}
 	}()
 
-	containers, err := d.docker.ListContainers(false, false, "")
+	containers, err := d.listContainers()
 	if err != nil {
 		return errors.New("Error connecting to docker socket: " + err.Error())
 	}
@@ -55,6 +55,10 @@ func (d *DockerManager) Start() error {
 
 func (d *DockerManager) Stop() {
 	d.docker.StopAllMonitorEvents()
+}
+
+func (d *DockerManager) listContainers() ([]dockerclient.Container, error) {
+	return d.docker.ListContainers(false, false, "")
 }
 
 func (d *DockerManager) getService(id string) (*Service, error) {

--- a/http.go
+++ b/http.go
@@ -101,6 +101,7 @@ func (s *HTTPServer) addService(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	service.Manual = true
 	s.list.AddService(id, *service)
 }
 
@@ -165,6 +166,7 @@ func (s *HTTPServer) updateService(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	service.Manual = true
 	// todo: this probably needs to be moved. consider stop event in the
 	// middle of sending PATCH. container would not be removed.
 	s.list.AddService(id, service)

--- a/http.go
+++ b/http.go
@@ -11,12 +11,14 @@ type HTTPServer struct {
 	config *Config
 	list   ServiceListProvider
 	server *http.Server
+	docker *DockerManager
 }
 
-func NewHTTPServer(c *Config, list ServiceListProvider) *HTTPServer {
+func NewHTTPServer(c *Config, list ServiceListProvider, docker *DockerManager) *HTTPServer {
 	s := &HTTPServer{
 		config: c,
 		list:   list,
+		docker: docker,
 	}
 
 	router := mux.NewRouter()
@@ -27,6 +29,9 @@ func NewHTTPServer(c *Config, list ServiceListProvider) *HTTPServer {
 	router.HandleFunc("/services/{id}", s.removeService).Methods("DELETE")
 
 	router.HandleFunc("/set/ttl", s.setTTL).Methods("PUT")
+
+	router.HandleFunc("/reload", s.reloadServices).Methods("POST")
+	router.HandleFunc("/reload/{id}", s.reloadService).Methods("POST")
 
 	s.server = &http.Server{Addr: c.httpAddr, Handler: router}
 
@@ -176,4 +181,53 @@ func (s *HTTPServer) setTTL(w http.ResponseWriter, req *http.Request) {
 
 	s.config.ttl = value
 
+}
+
+func (s *HTTPServer) reloadService(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	id, ok := vars["id"]
+	if !ok {
+		http.Error(w, "ID required", http.StatusBadRequest)
+		return
+	}
+
+	service, err := s.docker.getService(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.list.AddService(id, *service)
+}
+
+func (s *HTTPServer) reloadServices(w http.ResponseWriter, req *http.Request) {
+	deletes := make(map[string]bool)
+	for id, service := range s.list.GetAllServices() {
+		if !service.Manual {
+			deletes[id] = true
+		}
+	}
+
+	containers, err := s.docker.listContainers()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	for _, container := range containers {
+		deletes[container.Id] = false
+		service, err := s.docker.getService(container.Id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.list.AddService(container.Id, *service)
+	}
+
+	for id, delete := range deletes {
+		if delete {
+			s.list.RemoveService(id)
+		}
+	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -14,7 +14,7 @@ func TestServiceRequests(t *testing.T) {
 	config := NewConfig()
 	config.httpAddr = TestAddr
 
-	server := NewHTTPServer(config, NewDNSServer(config))
+	server := NewHTTPServer(config, NewDNSServer(config), nil)
 	go server.Start()
 
 	// Allow some time for server to start

--- a/http_test.go
+++ b/http_test.go
@@ -28,13 +28,13 @@ func TestServiceRequests(t *testing.T) {
 		{"GET", "/services/foo", "", "", 404},
 		{"PUT", "/services/foo", `{"name": "foo"}`, "", 500},
 		{"PUT", "/services/foo", `{"name": "foo", "image": "bar", "ip": "127.0.0.1", "aliases": ["foo.docker"]}`, "", 200},
-		{"GET", "/services/foo", "", `{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"]}`, 200},
+		{"GET", "/services/foo", "", `{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"],"Manual":true}`, 200},
 		{"PUT", "/services/boo", `{"name": "baz", "image": "bar", "ip": "127.0.0.2"}`, "", 200},
-		{"GET", "/services", "", `{"boo":{"Name":"baz","Image":"bar","Ip":"127.0.0.2","Ttl":-1,"Aliases":null},"foo":{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"]}}`, 200},
+		{"GET", "/services", "", `{"boo":{"Name":"baz","Image":"bar","Ip":"127.0.0.2","Ttl":-1,"Aliases":null,"Manual":true},"foo":{"Name":"foo","Image":"bar","Ip":"127.0.0.1","Ttl":-1,"Aliases":["foo.docker"],"Manual":true}}`, 200},
 		{"PATCH", "/services/boo", `{"name": "bar", "ttl": 20, "image": "bar"}`, "", 200},
-		{"GET", "/services/boo", "", `{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null}`, 200},
+		{"GET", "/services/boo", "", `{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null,"Manual":true}`, 200},
 		{"DELETE", "/services/foo", ``, "", 200},
-		{"GET", "/services", "", `{"boo":{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null}}`, 200},
+		{"GET", "/services", "", `{"boo":{"Name":"bar","Image":"bar","Ip":"127.0.0.2","Ttl":20,"Aliases":null,"Manual":true}}`, 200},
 	}
 
 	for _, input := range tests {

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	httpServer := NewHTTPServer(config, dnsServer)
+	httpServer := NewHTTPServer(config, dnsServer, docker)
 	go func() {
 		if err := httpServer.Start(); err != nil {
 			log.Fatal(err)

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,12 @@ curl http://dnsdock.docker/services/serviceid -X PATCH --data-ascii '{"ttl": 0}'
 
 # set new default TTL value
 curl http://dnsdock.docker/set/ttl -X PUT --data-ascii '10'
+
+# reload a service with its Docker metadata
+curl http://dnsdock.docker/reload/serviceID -X POST
+
+# reload all services with their Docker metadata
+curl http://dnsdock.docker/reload -X POST
 ```
 
 


### PR DESCRIPTION
One possible solution to #22 without introducing an explicit heartbeat (a feature called out in the third paragraph of the README) is to allow users to trigger a resync of one or all Docker containers via the existing HTTP interface. Users would have the choice to either manually trigger resync after container renames (or other container metadata changes) or to automatically trigger the resync via a cron-type scheduled mechanism.

Some notes:
- The sync does not update the _list_ of containers, just the metadata of containers known to exist.
- Sync will overwrite any manual changes to the service.
- General sync (the `/sync` endpoint) should ignore any services that are not tied to containers.
