### PR TITLE
Fix typo in URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 ## dnsdock
 
 DNS server for automatic docker container discovery. Simplified version of
-[crosbymichael/skydock](https://github.com/crsbymichael/skydock).
+[crosbymichael/skydock](https://github.com/crosbymichael/skydock).
 
 This project was initially created and maintained by [tonistiigi](https://github.com/tonistiigi).
 


### PR DESCRIPTION
Fixed a typo in the readme, the URL for skydoc was missing an 'o'.