### PR TITLE
Fix for labels for tags and name override each other

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,8 @@ docker run -e DNSDOCK_ALIAS=db.docker,sql.docker -e DNSDOCK_TTL=10 \
 # matches db.docker and sql.docker
 ```
 
+Service metadata syntax by [progrium/registrator](https://github.com/progrium/registrator) is also supported.
+
 #### Overrides with docker labels
 
 If you wish to fine tune the DNS response addresses you can define specific labels during 
@@ -239,6 +241,8 @@ container creation. This overrides the default matching scheme from container an
 
 Supported labels are `com.dnsdock.ignore`, `com.dnsdock.alias`, `com.dnsdock.name`, `com.dnsdock.tags`, `com.dnsdock.image`,
 `com.dnsdock.ttl`, `com.dnsdock.region`, and `com.dnsdock.ip_addr`
+
+Names use the following format **[tag].[name].[region].[image].[environment].[domain]**
 
 ```
 docker run -l com.dnsdock.name=master -l com.dnsdocker.image=mysql -l com.dnsdock.ttl=10 \
@@ -252,12 +256,10 @@ docker run -l com.dnsdock.alias=db.docker,sql.docker -l com.dnsdock.ttl=10 \
 # matches db.docker and sql.docker
 ```
 
-Service metadata syntax by [progrium/registrator](https://github.com/progrium/registrator) is also supported.
-
 ```
-docker run -l com.dnsdock.tags=master -l com.dnsdock.name=mysql -l com.dnsdock.region=us2 \
+docker run -l com.dnsdock.tags=master -l com.dnsdock.name=db -l com.dnsdock.region=us2 -l com.dnsdock.image=mysql \
            --name mymysql mysqlimage
-# matches master.mysql.us2.docker
+# matches master.db.us2.mysql.docker
 ```
 
 If you want dnsdock to skip processing a specific container set its

--- a/src/core/docker.go
+++ b/src/core/docker.go
@@ -202,7 +202,7 @@ func splitEnv(in []string) (out map[string]string) {
 }
 
 func overrideFromLabels(in *servers.Service, labels map[string]string) (out *servers.Service) {
-	var region string
+	var region, tags string
 	for k, v := range labels {
 		if k == "com.dnsdock.ignore" {
 			return nil
@@ -217,11 +217,7 @@ func overrideFromLabels(in *servers.Service, labels map[string]string) (out *ser
 		}
 
 		if k == "com.dnsdock.tags" {
-			if len(v) == 0 {
-				in.Name = ""
-			} else {
-				in.Name = strings.Split(v, ",")[0]
-			}
+			tags = v
 		}
 
 		if k == "com.dnsdock.image" {
@@ -260,8 +256,13 @@ func overrideFromLabels(in *servers.Service, labels map[string]string) (out *ser
 		}
 	}
 
+	if len(tags) > 0 {
+		// Currently only supports the first tag, but should be able to create multiple services,
+		// i.e. an array for in.Name, to support multiple service creation
+		in.Name = strings.Split(tags, ",")[0] + "." + in.Name
+	}
 	if len(region) > 0 {
-		in.Image = in.Image + "." + region
+		in.Image = region + "." + in.Image
 	}
 	out = in
 	return

--- a/src/core/docker_test.go
+++ b/src/core/docker_test.go
@@ -109,3 +109,30 @@ func TestOverrideFromEnv(t *testing.T) {
 	}
 
 }
+
+func TestOverrideFromLabels(t *testing.T) {
+	getService := func() *servers.Service {
+		service := servers.NewService()
+		service.Name = "myfoo"
+		service.Image = "mybar"
+		return service
+	}
+
+	s := getService()
+	s = overrideFromLabels(s, map[string]string{"com.dnsdock.ignore": "1"})
+	if s != nil {
+		t.Error("Skipping failed")
+	}
+
+	s = getService()
+	s = overrideFromLabels(s, map[string]string{"com.dnsdock.name": "master", "com.dnsdock.image": "mysql", "com.dnsdock.ttl": "22"})
+	if s.Name != "master" || s.Image != "mysql" || s.TTL != 22 {
+		t.Error("Invalid name, image label overrides", s)
+	}
+
+	s = getService()
+	s = overrideFromLabels(s, map[string]string{"com.dnsdock.tags": "something,other", "com.dnsdock.name": "master", "com.dnsdock.region": "us2", "com.dnsdock.image": "mysql"})
+	if s.Name != "something.master" || s.Image != "us2.mysql" {
+		t.Error("Invalid tags, name, region, image label override", s)
+	}
+}

--- a/src/servers/dnsserver.go
+++ b/src/servers/dnsserver.go
@@ -36,10 +36,11 @@ func NewService() (s *Service) {
 }
 func (s Service) String() string {
 	return fmt.Sprintf(` Name:    %s
+                       Image: %s
                        Aliases: %s
                        IPs:     %s
                        TTL:     %d
-        `, s.Name, s.Aliases, s.IPs, s.TTL)
+        `, s.Name, s.Image, s.Aliases, s.IPs, s.TTL)
 }
 
 // ServiceListProvider represents the entrypoint to get containers


### PR DESCRIPTION
Based on the conversation in #88 here is a (kong overdue) PR that addresses a few issues with domain name creation.

Names are now formed based on the following format:

`[tag].[name].[region].[image].[environment].[domain]`

Just like the current implementation this will only take the first tag if there is a csv value for tags. A future PR can add support for creating additional aliases based on multiple tag values.
