### PR TITLE
fix: empty container IP address while it's attached to another container

### DIFF
--- a/internal/core/docker_test.go
+++ b/internal/core/docker_test.go
@@ -87,13 +87,13 @@ func TestOverrideFromEnv(t *testing.T) {
 
 	s := getService()
 	s = overrideFromEnv(s, map[string]string{"SERVICE_IGNORE": "1"})
-	if s != nil {
+	if s != nil && !s.IgnoredByUser {
 		t.Error("Skipping failed")
 	}
 
 	s = getService()
 	s = overrideFromEnv(s, map[string]string{"DNSDOCK_IGNORE": "1"})
-	if s != nil {
+	if s != nil && !s.IgnoredByUser {
 		t.Error("Skipping failed(2)")
 	}
 

--- a/internal/servers/dnsserver.go
+++ b/internal/servers/dnsserver.go
@@ -30,7 +30,7 @@ type Service struct {
 	IPs           []net.IP
 	TTL           int
 	Aliases       []string
-	IgnoredByUser bool
+	IgnoredByUser bool `json:"-"`
 
 	// Provider tracks the creator of a service
 	Provider string `json:"-"`


### PR DESCRIPTION
When a container is attached to another container's networking stack, the IP address of the container is empty and resulting `DockerManager` keep triggering retry and restart. 
This PR fills the empty IP address with the attached container's IP address.

Note: The restart loop triggered even the `com.dnsdock.ignore` label has added because `overrideFromLabels()` and `overrideFromEnv()` will return `nil` and cause `DockerManger.getService()` returns a non-nil error when `service == nil` and trigger the restart loop. Therefore, I explicitly add a field in `Service` struct to mark the service as 'ignored' instead of returning `nil`, 